### PR TITLE
feature/add-ingress-controller-and-skaffold-config-for-auth-srv

### DIFF
--- a/auth/src/index.ts
+++ b/auth/src/index.ts
@@ -5,7 +5,12 @@ import { json } from 'body-parser'
 const app = express();
 app.use(json());
 
+app.get('/api/users/currentuser', (req, res) => {
+    console.log("Hitting the correct URL")
+    res.json({ message: "api is working fine!" })
+})
+
 const port = 3000;
 app.listen(port, () => {
-    console.log(`Listening on Port ${port}!!`)
+    console.log(`Listening on Port ${port}!`)
 })

--- a/infra/k8s/auth-depl.yaml
+++ b/infra/k8s/auth-depl.yaml
@@ -7,14 +7,14 @@ spec:
   selector:
     matchLabels:
       app: auth
-  templates:
+  template:
     metadata:
       labels:
         app: auth
     spec:
       containers:
         - name: auth
-          image: aqibj/auth:1.0
+          image: aqibj/auth:0.0.1
 ---
 apiVersion: v1
 kind: Service

--- a/infra/k8s/ingress-srv.yaml
+++ b/infra/k8s/ingress-srv.yaml
@@ -1,0 +1,31 @@
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+  name: nginx
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: "true"
+spec:
+  controller: k8s.io/ingress-nginx
+
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-srv
+  annotations:
+    nginx.ingress.kubernetes.io/use-regex: "true"
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: ticketing.dev
+      http:
+        paths:
+          - path: /api/users/?(.*)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: auth-srv
+                port:
+                  number: 3000

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,20 @@
+apiVersion: skaffold/v4beta3
+kind: Config
+manifests:
+  rawYaml:
+    - ./infra/k8s/*
+build:
+  local:
+    push: false
+  tagPolicy:
+    customTemplate:
+      template: "0.0.1"
+  artifacts:
+    - image: aqibj/auth
+      context: auth
+      docker:
+        dockerfile: Dockerfile
+      sync:
+        manual:
+          - src: "src/**/*.ts"
+            dest: .


### PR DESCRIPTION
1.  Add Ingress Nginx Controller rules with a route in Auth microservice.
2.  Implement the Skaffold configurations for auto-deployment and monitoring of all k8s objects in the codebase.